### PR TITLE
feat: Add SDK id and version to requests

### DIFF
--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -52,6 +52,8 @@ type resolveRequest struct {
 	Apply             bool                   `json:"apply"`
 	EvaluationContext map[string]interface{} `json:"evaluation_context"`
 	Flags             []string               `json:"flags"`
+	SdkId             string                 `json:"sdk_id"`
+	SdkVersion   	  string                 `json:"sdk_version"`
 }
 
 type resolveResponse struct {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -15,6 +15,11 @@ type FlagProvider struct {
 	ResolveClient resolveClient
 }
 
+var (
+    SDK_ID = "SDK_ID_GO_PROVIDER"
+    SDK_VERSION = ""
+)
+
 func NewFlagProvider(config APIConfig) (*FlagProvider, error) {
 	validationError := config.validate()
 	if validationError != nil {
@@ -64,7 +69,8 @@ func (e FlagProvider) resolveFlag(ctx context.Context, flag string, defaultValue
 	requestFlagName := fmt.Sprintf("flags/%s", flagName)
 	resp, err := e.ResolveClient.sendResolveRequest(ctx,
 		resolveRequest{ClientSecret: e.Config.APIKey,
-			Flags: []string{requestFlagName}, Apply: true, EvaluationContext: evalCtx})
+			Flags: []string{requestFlagName}, Apply: true, EvaluationContext: evalCtx,
+			SdkId: SDK_ID, SdkVersion: SDK_VERSION})
 
 	if err != nil {
 		return processResolveError(err, defaultValue)


### PR DESCRIPTION
It should be possible to set the vars at build time via `ldflags`, e.g.:
```
go build -ldflags="-X 'provider.SDK_VERSION=x.x.x'"
```
This part requires a bit more work and testing ☝️