### PR TITLE
fix: add a default endpoint to the provider

### DIFF
--- a/pkg/provider/models.go
+++ b/pkg/provider/models.go
@@ -15,18 +15,22 @@ type APIConfig struct {
 const (
 	APIRegionEU = iota
 	APIRegionUS = iota
+	APIRegionsGlobal = iota
 )
 
 // Private types below
 
 const euAPIURL = "https://resolver.eu.confidence.dev/v1"
 const usAPIURL = "https://resolver.us.confidence.dev/v1"
+const globalAPIURL = "https://resolver.confidence.dev/v1"
 
 func (r APIRegion) apiURL() string {
 	if r == APIRegionEU {
 		return euAPIURL
 	} else if r == APIRegionUS {
 		return usAPIURL
+	} else if r == APIRegionsGlobal {
+		return globalAPIURL
 	}
 	return ""
 }

--- a/pkg/provider/provider_internal_test.go
+++ b/pkg/provider/provider_internal_test.go
@@ -190,7 +190,7 @@ func TestResolveWithNonExistingFlag(t *testing.T) {
 
 func client(response resolveResponse, errorToReturn error) *openfeature.Client {
 	provider := FlagProvider{Config: APIConfig{APIKey: "apikey",
-		Region: APIRegionEU}, ResolveClient: MockResolveClient{MockedResponse: response, MockedError: errorToReturn}}
+		Region: APIRegionsGlobal}, ResolveClient: MockResolveClient{MockedResponse: response, MockedError: errorToReturn}}
 	openfeature.SetProvider(provider)
 	return openfeature.NewClient("testApp")
 }


### PR DESCRIPTION
Previously, the region would default to Europe. This PR is changing this to GLOBAL and is specifying a URL for that.