### PR TITLE
fix: targeting key serialization fix

### DIFF
--- a/demo/GoDemoApp.go
+++ b/demo/GoDemoApp.go
@@ -24,11 +24,10 @@ func main() {
 
 	attributes := make(map[string]interface{})
 	targetingKey := uuid.New().String()
-	attributes["targeting_key"] = targetingKey
 
 	fmt.Println(" Random UUID -> " + targetingKey)
 
-	of := openfeature.NewEvaluationContext("", attributes)
+	of := openfeature.NewEvaluationContext(targetingKey, attributes)
 
 	colorValue, _ := client.StringValue(context.Background(), "hawkflag.color", "defaultValue", of)
 	messageValue, _ := client.StringValue(context.Background(), "hawkflag.message", "defaultValue", of)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -69,7 +69,7 @@ func (e FlagProvider) resolveFlag(ctx context.Context, flag string, defaultValue
 	requestFlagName := fmt.Sprintf("flags/%s", flagName)
 	resp, err := e.ResolveClient.sendResolveRequest(ctx,
 		resolveRequest{ClientSecret: e.Config.APIKey,
-			Flags: []string{requestFlagName}, Apply: true, EvaluationContext: evalCtx,
+			Flags: []string{requestFlagName}, Apply: true, EvaluationContext: processTargetingKey(evalCtx),
 			Sdk: sdk{Id: SDK_ID, Version: SDK_VERSION}})
 
 	if err != nil {
@@ -94,6 +94,15 @@ func (e FlagProvider) resolveFlag(ctx context.Context, flag string, defaultValue
 	}
 
 	return processResolvedFlag(resolvedFlag, defaultValue, expectedKind, propertyPath)
+}
+
+func processTargetingKey(evalCtx openfeature.FlattenedContext) openfeature.FlattenedContext {
+	newEvalContext := openfeature.FlattenedContext{}
+	newEvalContext = evalCtx
+	if targetingKey, exists := evalCtx["targetingKey"]; exists {
+		newEvalContext["targeting_key"] = targetingKey
+	}
+	return newEvalContext
 }
 
 func (e FlagProvider) Hooks() []openfeature.Hook {


### PR DESCRIPTION
The GO SDK flattens the context using [targetingKey](https://github.com/open-feature/go-sdk/blob/2944608562d04521fcf92000948a22012e630471/openfeature/provider.go#L36) as key for the targeting key value in the context.

Other SDK pass the (non-flattened) EvaluationContext object to the Provider and let the latter decide how to encode the context. We might want to investigate more why the implementation in GO differs in these regards.

In the meantime, this fix allows to keep backwards compatibility and inter-operability between different backends at the cost of sending duplicate data. Note that the user can always set `targeting_key` as an attribute