### PR TITLE
fix: handle panic on null values

### DIFF
--- a/pkg/confidence/confidence_internal_test.go
+++ b/pkg/confidence/confidence_internal_test.go
@@ -35,6 +35,19 @@ func TestResolveBoolValue(t *testing.T) {
 	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
 }
 
+func TestResolveBoolNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetBoolFlag(context.Background(), "test-flag.boolean-key-null-value", true)
+
+	assert.Equal(t, true, evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
+}
+
 func TestResolveIntValue(t *testing.T) {
 	client := client(t, templateResponse(), nil)
 	client.PutContext("targeting_key", "user1")
@@ -48,9 +61,13 @@ func TestResolveIntNullValue(t *testing.T) {
 	client := client(t, templateResponse(), nil)
 	client.PutContext("targeting_key", "user1")
 
-	evalDetails := client.GetIntFlag(context.Background(), "test-flag.integer-key-null", 99)
+	evalDetails := client.GetIntFlag(context.Background(), "test-flag.integer-key-null-value", 99)
 
 	assert.Equal(t, int64(99), evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
 }
 
 func TestResolveDoubleValue(t *testing.T) {
@@ -69,6 +86,10 @@ func TestResolveDoubleNullValue(t *testing.T) {
 	evalDetails := client.GetDoubleFlag(context.Background(), "test-flag.double-key-null-value", 99.99)
 
 	assert.Equal(t, 99.99, evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
 }
 
 func TestResolveStringValue(t *testing.T) {
@@ -80,6 +101,19 @@ func TestResolveStringValue(t *testing.T) {
 	assert.Equal(t, "treatment", evalDetails.Value)
 }
 
+func TestResolveStringValueNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetStringFlag(context.Background(), "test-flag.string-key-null-value", "default")
+
+	assert.Equal(t, "default", evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
+}
+
 func TestResolveObjectValue(t *testing.T) {
 	client := client(t, templateResponse(), nil)
 	client.PutContext("targeting_key", "user1")
@@ -89,7 +123,7 @@ func TestResolveObjectValue(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func TestResolveNestedValue(t *testing.T) {
+func TestResolveBoolNestedValue(t *testing.T) {
 	client := client(t, templateResponse(), nil)
 	client.PutContext("targeting_key", "user1")
 
@@ -97,12 +131,97 @@ func TestResolveNestedValue(t *testing.T) {
 	assert.Equal(t, false, evalDetails.Value)
 }
 
+func TestResolveBoolNestedNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetBoolFlag(context.Background(), "test-flag.struct-key.boolean-key-null-value", true)
+	assert.Equal(t, true, evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
+}
+
+func TestResolveStringNestedValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetStringFlag(context.Background(), "test-flag.struct-key.string-key", "default")
+	assert.Equal(t, "treatment-struct", evalDetails.Value)
+}
+
+func TestResolveStringNestedNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetStringFlag(context.Background(), "test-flag.struct-key.string-key-null-value", "default")
+	assert.Equal(t, "default", evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
+}
+
 func TestResolveDoubleNestedValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetDoubleFlag(context.Background(), "test-flag.struct-key.double-key", 99.99)
+	assert.Equal(t, 123.23, evalDetails.Value)
+}
+
+func TestResolveDoubleNestedNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetDoubleFlag(context.Background(), "test-flag.struct-key.double-key-null-value", 99.99)
+	assert.Equal(t, 99.99, evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
+}
+
+func TestResolveIntNestedValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetIntFlag(context.Background(), "test-flag.struct-key.integer-key", 99)
+	assert.Equal(t, int64(23), evalDetails.Value)
+}
+
+func TestResolveIntNestedNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetIntFlag(context.Background(), "test-flag.struct-key.integer-key-null-value", 99)
+	assert.Equal(t, int64(99), evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
+}
+
+// Struct - In - Struct
+func TestResolveBoolNestedStructValue(t *testing.T) {
 	client := client(t, templateResponse(), nil)
 	client.PutContext("targeting_key", "user1")
 
 	evalDetails := client.GetBoolFlag(context.Background(), "test-flag.struct-key.nested-struct-key.nested-boolean-key", true)
 	assert.Equal(t, false, evalDetails.Value)
+}
+
+func TestResolveBoolNestedStructNullValue(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetBoolFlag(context.Background(), "test-flag.struct-key.nested-struct-key.nested-boolean-key-null-value", true)
+	assert.Equal(t, true, evalDetails.Value)
+	assert.Equal(t, ErrorCode(""), evalDetails.ErrorCode)
+	assert.Equal(t, "", evalDetails.ErrorMessage)
+	assert.Equal(t, TargetingMatchReason, evalDetails.Reason)
+	assert.Equal(t, "flags/test-flag/variants/treatment", evalDetails.Variant)
 }
 
 func TestResolveWholeFlagAsObject(t *testing.T) {
@@ -130,6 +249,22 @@ func TestResolveWholeFlagAsObjectWithInts(t *testing.T) {
 
 	assert.Equal(t, reflect.Int64, reflect.ValueOf(nestedIntValue).Kind())
 	assert.Equal(t, int64(23), nestedIntValue)
+}
+
+func TestResolveWholeFlagAsObjectWithNulls(t *testing.T) {
+	client := client(t, templateResponse(), nil)
+	client.PutContext("targeting_key", "user1")
+
+	evalDetails := client.GetObjectFlag(context.Background(), "test-flag", map[string]interface{}{})
+
+	value, _ := evalDetails.Value.(map[string]interface{})
+	rootNullValue := value["boolean-key-null-value"]
+
+	assert.Nil(t, rootNullValue)
+
+	nestedNullValue := value["struct-key"].(map[string]interface{})["string-key-null-value"]
+
+	assert.Nil(t, nestedNullValue)
 }
 
 func TestResolveWithWrongType(t *testing.T) {
@@ -179,79 +314,108 @@ func templateResponse() ResolveResponse {
 func templateResponseWithFlagName(flagName string) ResolveResponse {
 	templateResolveResponse := fmt.Sprintf(`
 {
- "resolvedFlags": [
- {
-  "flag": "flags/%[1]s",
-  "variant": "flags/%[1]s/variants/treatment",
-  "value": {
-   "struct-key": {
-    "boolean-key": false,
-    "string-key": "treatment-struct",
-    "double-key": 123.23,
-    "integer-key": 23,
-	"nested-struct-key": {
-		"nested-boolean-key": false
-	}
-   },
-   "boolean-key": true,
-   "string-key": "treatment",
-   "double-key": 20.203,
-   "double-key-null-value": null,
-   "integer-key": 40,
-   "integer-key-null-value": null
-  },
-  "flagSchema": {
-   "schema": {
-    "struct-key": {
-     "structSchema": {
-      "schema": {
-       "boolean-key": {
-        "boolSchema": {}
-       },
-       "string-key": {
-        "stringSchema": {}
-       },
-       "double-key": {
-        "doubleSchema": {}
-       },
-       "integer-key": {
-        "intSchema": {}
-       },
-	   "nested-struct-key": {
-		"structSchema": {
-			"schema": {
-				"nested-boolean-key": {
-					"boolSchema": {}
-				}
-			}
-		}
-	   }
-      }
-     }
-    },
-    "boolean-key": {
-     "boolSchema": {}
-    },
-    "string-key": {
-     "stringSchema": {}
-    },
-    "double-key": {
-     "doubleSchema": {}
-    },
-	"double-key-null-value": {
-     "doubleSchema": {}
-	},
-    "integer-key": {
-     "intSchema": {}
-    },
-	"integer-key-null-value": {
-     "intSchema": {}
-	}
-   }
-  },
-  "reason": "RESOLVE_REASON_MATCH"
- }],
- "resolveToken": ""
+    "resolvedFlags": [
+        {
+            "flag": "flags/%[1]s",
+            "variant": "flags/%[1]s/variants/treatment",
+            "value": {
+                "struct-key": {
+                    "boolean-key": false,
+                    "boolean-key-null-value": null,
+                    "string-key": "treatment-struct",
+                    "string-key-null-value": null,
+                    "double-key": 123.23,
+                    "double-key-null-value": null,
+                    "integer-key": 23,
+                    "integer-key-null-value": null,
+                    "nested-struct-key": {
+                        "nested-boolean-key": false,
+                        "nested-boolean-key-null-value": null
+                    }
+                },
+                "boolean-key": true,
+                "boolean-key-null-value": null,
+                "string-key": "treatment",
+                "string-key-null-value": null,
+                "double-key": 20.203,
+                "double-key-null-value": null,
+                "integer-key": 40,
+                "integer-key-null-value": null
+            },
+            "flagSchema": {
+                "schema": {
+                    "struct-key": {
+                        "structSchema": {
+                            "schema": {
+                                "boolean-key": {
+                                    "boolSchema": {}
+                                },
+                                "boolean-key-null-value": {
+                                    "boolSchema": {}
+                                },
+                                "string-key": {
+                                    "stringSchema": {}
+                                },
+                                "string-key-null-value": {
+                                    "stringSchema": {}
+                                },
+                                "double-key": {
+                                    "doubleSchema": {}
+                                },
+                                "double-key-null-value": {
+                                    "doubleSchema": {}
+                                },
+                                "integer-key": {
+                                    "intSchema": {}
+                                },
+                                "integer-key-null-value": {
+                                    "intSchema": {}
+                                },
+                                "nested-struct-key": {
+                                    "structSchema": {
+                                        "schema": {
+                                            "nested-boolean-key": {
+                                                "boolSchema": {}
+                                            },
+                                            "nested-boolean-key-null-value": {
+                                                "boolSchema": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "boolean-key": {
+                        "boolSchema": {}
+                    },
+                    "boolean-key-null-value": {
+                        "boolSchema": {}
+                    },
+                    "string-key": {
+                        "stringSchema": {}
+                    },
+                    "string-key-null-value": {
+                        "stringSchema": {}
+                    },
+                    "double-key": {
+                        "doubleSchema": {}
+                    },
+                    "double-key-null-value": {
+                        "doubleSchema": {}
+                    },
+                    "integer-key": {
+                        "intSchema": {}
+                    },
+                    "integer-key-null-value": {
+                        "intSchema": {}
+                    }
+                }
+            },
+            "reason": "RESOLVE_REASON_MATCH"
+        }
+    ],
+    "resolveToken": ""
 }
 `, flagName)
 	var result ResolveResponse

--- a/pkg/confidence/utils.go
+++ b/pkg/confidence/utils.go
@@ -217,7 +217,7 @@ func typeMismatchError(defaultValue interface{}) InterfaceResolutionDetail {
 
 func ToBoolResolutionDetail(res InterfaceResolutionDetail,
 	defaultValue bool) BoolResolutionDetail {
-	if res.ResolutionDetail.Reason == TargetingMatchReason {
+	if res.ResolutionDetail.Reason == TargetingMatchReason && res.Value != nil {
 		v, ok := res.Value.(bool)
 		if ok {
 			return BoolResolutionDetail{
@@ -246,7 +246,7 @@ func ToBoolResolutionDetail(res InterfaceResolutionDetail,
 
 func ToStringResolutionDetail(res InterfaceResolutionDetail,
 	defaultValue string) StringResolutionDetail {
-	if res.ResolutionDetail.Reason == TargetingMatchReason {
+	if res.ResolutionDetail.Reason == TargetingMatchReason && res.Value != nil {
 		v, ok := res.Value.(string)
 		if ok {
 			return StringResolutionDetail{
@@ -255,7 +255,7 @@ func ToStringResolutionDetail(res InterfaceResolutionDetail,
 			}
 		}
 
-		err := NewTypeMismatchResolutionError("Unable to convert response property to boolean")
+		err := NewTypeMismatchResolutionError("Unable to convert response property to string")
 
 		return StringResolutionDetail{
 			Value: defaultValue,
@@ -277,7 +277,7 @@ func ToStringResolutionDetail(res InterfaceResolutionDetail,
 
 func ToFloatResolutionDetail(res InterfaceResolutionDetail,
 	defaultValue float64) FloatResolutionDetail {
-	if res.ResolutionDetail.Reason == TargetingMatchReason {
+	if res.ResolutionDetail.Reason == TargetingMatchReason && res.Value != nil {
 		v, ok := res.Value.(float64)
 		if ok {
 			return FloatResolutionDetail{
@@ -316,7 +316,7 @@ func ToObjectResolutionDetail(res InterfaceResolutionDetail, defaultValue interf
 			}
 		}
 
-		err := NewTypeMismatchResolutionError("Unable to convert response property to float")
+		err := NewTypeMismatchResolutionError("Unable to convert response property to object")
 
 		return InterfaceResolutionDetail{
 			Value: defaultValue,
@@ -338,7 +338,7 @@ func ToObjectResolutionDetail(res InterfaceResolutionDetail, defaultValue interf
 
 func ToIntResolutionDetail(res InterfaceResolutionDetail,
 	defaultValue int64) IntResolutionDetail {
-	if res.ResolutionDetail.Reason == TargetingMatchReason {
+	if res.ResolutionDetail.Reason == TargetingMatchReason && res.Value != nil {
 		v, ok := res.Value.(int64)
 		if ok {
 			return IntResolutionDetail{

--- a/pkg/confidence/utils_test.go
+++ b/pkg/confidence/utils_test.go
@@ -481,7 +481,7 @@ func TestToStringResolutionDetail(t *testing.T) {
 				Variant:      "",
 				Reason:       ErrorReason,
 				ErrorCode:    TypeMismatchCode,
-				ErrorMessage: "Unable to convert response property to boolean",
+				ErrorMessage: "Unable to convert response property to string",
 				FlagMetadata: nil,
 			},
 		}


### PR DESCRIPTION
Issue related: https://github.com/spotify/confidence-sdk-go/issues/61

This pull request includes several changes to the `pkg/confidence` package, primarily focusing on adding new test cases for resolving null values and handling type mismatches more gracefully. The most important changes are listed below:

### New Test Cases for Null Values:
* Added `TestResolveBoolNullValue`, `TestResolveIntNullValue`, `TestResolveDoubleNullValue`, and `TestResolveStringValueNullValue` to test the resolution of null values for boolean, integer, double, and string flags respectively. (`pkg/confidence/confidence_internal_test.go`, [[1]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R38-R50) [[2]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R60-R72) [[3]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R82-R94) [[4]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R104-R116)
* Added nested test cases for null values, such as `TestResolveBoolNestedNullValue`, `TestResolveStringNestedNullValue`, `TestResolveDoubleNestedNullValue`, and `TestResolveIntNestedNullValue`. (`pkg/confidence/confidence_internal_test.go`, [pkg/confidence/confidence_internal_test.goL74-R226](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85L74-R226))

### Template Response Enhancements:
* Updated `templateResponseWithFlagName` to include null values for various keys, enhancing the template response to handle null values in different contexts. (`pkg/confidence/confidence_internal_test.go`, [[1]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R324-R343) [[2]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R353-R381) [[3]](diffhunk://#diff-0397b80202ef4a0ca4601c193a901bc7df3c4b81d555c776341f83d73e289c85R392-R417)

### Utility Function Improvements:
* Modified `replaceNumbers` to handle `json.Number` more robustly, ensuring proper conversion to `float64` and `int64` even when values are null. (`pkg/confidence/utils.go`, [pkg/confidence/utils.goL163-R183](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL163-R183))
* Enhanced type conversion functions (`ToBoolResolutionDetail`, `ToStringResolutionDetail`, `ToFloatResolutionDetail`, `ToIntResolutionDetail`, and `ToObjectResolutionDetail`) to check for null values before attempting type conversion. (`pkg/confidence/utils.go`, [[1]](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL212-R220) [[2]](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL241-R249) [[3]](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL272-R280) [[4]](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL311-R319) [[5]](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL333-R341)

### Error Message Corrections:
* Corrected error messages in type conversion functions to accurately reflect the type being converted, e.g., changing "Unable to convert response property to boolean" to "Unable to convert response property to string". (`pkg/confidence/utils.go`, [[1]](diffhunk://#diff-06cb179db5dad83bda71a638eade2b8b1af1777f374defd1263ef764fd38cf3aL250-R258) [[2]](diffhunk://#diff-fcc0dacfa6a0f9abda4e7300b89ff63046d2816efba47d2cda42d8f4c0c95cd2L484-R484)