### PR TITLE
fix: move defer resp.Body.Close() after response check

### DIFF
--- a/pkg/confidence/EventUploader.go
+++ b/pkg/confidence/EventUploader.go
@@ -46,8 +46,8 @@ func (e HttpEventUploader) upload(ctx context.Context, request EventBatchRequest
 		e.Logger.Warn("Failed to perform upload request", "error", err)
 		return
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		e.Logger.Warn("Failed to upload event", "status", resp.Status)
 	}
-	defer resp.Body.Close()
 }


### PR DESCRIPTION
## Summary

Moves `defer resp.Body.Close()` to immediately follow the error check after `Client.Do()`, following Go best practices.

## The Issue

In `pkg/confidence/EventUploader.go`, the `defer resp.Body.Close()` was placed at the end of the function after the status code check:

```go
resp, err := e.Client.Do(req)
if err != nil {
    e.Logger.Warn("Failed to perform upload request", "error", err)
    return
}
if resp.StatusCode != http.StatusOK {
    e.Logger.Warn("Failed to upload event", "status", resp.Status)
}
defer resp.Body.Close()  // ← Was here at line 52
```

## The Fix

Move the defer to immediately after successfully obtaining the response:

```go
resp, err := e.Client.Do(req)
if err != nil {
    e.Logger.Warn("Failed to perform upload request", "error", err)
    return
}
defer resp.Body.Close()  // ← Now here, following Go best practice
if resp.StatusCode != http.StatusOK {
    e.Logger.Warn("Failed to upload event", "status", resp.Status)
}
```

## Why This Matters

1. **Go idiom**: The standard Go pattern is to defer `Close()` immediately after confirming the resource was successfully acquired
2. **Consistency**: The `http_resolve_client.go` file in this same package already follows this pattern correctly (see line 126)
3. **Defensive coding**: While the current code works, placing the defer later makes it easier to accidentally introduce bugs if code is added between the request and the defer